### PR TITLE
Upgrade react peer dependency to 15.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {
-    "react": "^15.0.1"
+    "react": "^15.3.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
This upgrade will allow usage of `react-test-renderer`, which will be useful for snapshot testing.