### PR TITLE
Fix not-hoisted component static properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/traveloka/react-diode#readme",
   "dependencies": {
     "deep-extend": "^0.4.1",
-    "hoist-non-react-statics": "^1.2.0",
+    "hoist-non-react-statics": "^2.5.0",
     "lodash.find": "^4.3.0",
     "object-assign": "^4.0.1"
   },
@@ -60,6 +60,7 @@
     "codecov": "^1.0.1",
     "enzyme": "^2.2.0",
     "flow-bin": "^0.22.1",
+    "isomorphic-fetch": "^2.2.1",
     "marlint": "^1.5.3",
     "mocha": "^2.4.5",
     "nock": "^7.4.0",
@@ -68,7 +69,6 @@
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",
     "sinon": "^1.17.3",
-    "isomorphic-fetch": "^2.2.1",
     "sinon-chai": "^2.8.0"
   },
   "marlint": {

--- a/src/container/DiodeContainer.js
+++ b/src/container/DiodeContainer.js
@@ -96,7 +96,7 @@ function createContainer(
   ContainerConstructor.displayName = containerName;
   ContainerConstructor.componentName = componentName;
 
-  return ContainerConstructor;
+  return hoistStatics(ContainerConstructor, Component);
 }
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2277,9 +2277,9 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
\+ upgrade hoist-non-react-statics package to support react's `gDSFP` lifecycle

Bug:
```js
const Foo = () => <span>Hello world</span>
class MyContainer extends Component {
  static UI = Foo;

  render() {
	return this.props.children;
  }
}
export default Diode.createContainer(MyContainer, { ... });

// MyContainer consumer
render() {
  return (
	<MyContainer>
      <MyContainer.UI />
    </MyContainer>
  );
}
```
```
Invariant Violation: Element type is invalid: expected a string( for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in.
```

I have tested this fix on my local via `yarn link` & `yarn link react-diode` and it works.