### PR TITLE
[FIX] Queries don't get merged when containers are nested

### DIFF
--- a/src/container/DiodeContainer.js
+++ b/src/container/DiodeContainer.js
@@ -2,6 +2,7 @@
  * @flow
  */
 import React from 'react';
+import deepExtend from 'deep-extend';
 import objectAssign from 'object-assign';
 import hoistStatics from 'hoist-non-react-statics';
 import DiodeContainerQuery from '../query/DiodeContainerQuery';
@@ -10,16 +11,16 @@ import type { DiodeQueryMap } from '../tools/DiodeTypes';
 export type DiodeContainer = {
   query: DiodeContainerQuery,
   displayName: string,
-  componentName: string
-}
+  componentName: string,
+};
 
 export type DiodeContainerSpec = {
   wrapperInfo: {
-    [key: string]: string
+    [key: string]: string,
   },
   children?: Array<DiodeContainer>,
-  queries?: DiodeQueryMap
-}
+  queries?: DiodeQueryMap,
+};
 
 function createContainerComponent(Component, spec) {
   /* istanbul ignore next */
@@ -44,9 +45,7 @@ function createContainerComponent(Component, spec) {
         );
       }
 
-      return (
-        <Component {...this.props} />
-      );
+      return <Component {...this.props} />;
     }
   }
 
@@ -54,10 +53,7 @@ function createContainerComponent(Component, spec) {
   return hoistStatics(DiodeContainer, Component);
 }
 
-function createContainer(
-  Component,
-  spec: DiodeContainerSpec = {}
-): DiodeContainer {
+function createContainer(Component, spec: DiodeContainerSpec = {}): DiodeContainer {
   /* istanbul ignore next */
   const componentName = Component.displayName || Component.name;
   const containerName = `Diode(${componentName})`;
@@ -92,13 +88,13 @@ function createContainer(
     }
   };
 
-  ContainerConstructor.query = query;
+  ContainerConstructor.query = deepExtend(query, Component.query);
   ContainerConstructor.displayName = containerName;
   ContainerConstructor.componentName = componentName;
 
-  return hoistStatics(ContainerConstructor, Component);
+  return hoistStatics(ContainerConstructor, Component, { query: true });
 }
 
 module.exports = {
-  create: createContainer
+  create: createContainer,
 };

--- a/test/container/DiodeContainer.js
+++ b/test/container/DiodeContainer.js
@@ -8,7 +8,7 @@ import DiodeContainerQuery from '../../src/query/DiodeContainerQuery';
 chai.should();
 
 const Component = props => {
-  return <div className='test-component' />;
+  return <div className="test-component" />;
 };
 Component.displayName = 'TestComponent';
 
@@ -19,10 +19,10 @@ describe('DiodeContainer', () => {
         hello: {
           type: 'HelloQuery',
           fragmentStructure: {
-            world: null
-          }
-        }
-      }
+            world: null,
+          },
+        },
+      },
     });
     Container.query.should.be.instanceof(DiodeContainerQuery);
     Container.displayName.should.be.equal('Diode(TestComponent)');
@@ -40,8 +40,8 @@ describe('DiodeContainer', () => {
       wrapperInfo: {
         className: 'wrapper wrapper-small',
         'data-blocks-id': 1,
-        'data-blocks-type': 'block'
-      }
+        'data-blocks-type': 'block',
+      },
     });
     const c = render(<Container />);
     c.find('.wrapper.wrapper-small').should.have.length(1);
@@ -53,11 +53,11 @@ describe('DiodeContainer', () => {
       wrapperInfo: {
         className: 'wrapper wrapper-small',
         'data-blocks-id': 1,
-        'data-blocks-type': 'block'
-      }
+        'data-blocks-type': 'block',
+      },
     });
     const wrapperInfoFromProps = {
-      className: 'new-wrapper'
+      className: 'new-wrapper',
     };
     const c = render(<Container wrapperInfo={wrapperInfoFromProps} />);
     c.find('.wrapper.wrapper-small').should.have.length(0);
@@ -67,10 +67,10 @@ describe('DiodeContainer', () => {
 
   it('should be able to set wrapperInfo', () => {
     const Container = create(Component, {
-      wrapperInfo: { className: 'wrapper-old' }
+      wrapperInfo: { className: 'wrapper-old' },
     });
     Container.setWrapperInfo({
-      className: 'wrapper-new'
+      className: 'wrapper-new',
     });
     const c = render(<Container />);
     c.find('.wrapper-old').should.have.length(0);
@@ -79,7 +79,7 @@ describe('DiodeContainer', () => {
 
   it('should be able to get wrapperInfo', () => {
     const Container = create(Component, {
-      wrapperInfo: { 'data-x-y': 'value' }
+      wrapperInfo: { 'data-x-y': 'value' },
     });
     const xy = Container.getWrapperInfo('data-x-y');
     xy.should.be.equal('value');
@@ -96,13 +96,13 @@ describe('DiodeContainer', () => {
         hello: {
           type: 'HelloQuery',
           fragmentStructure: {
-            x: 'y'
-          }
-        }
-      }
+            x: 'y',
+          },
+        },
+      },
     });
     const Container = create(Component, {
-      children: [ChildContainer]
+      children: [ChildContainer],
     });
     Container.getChildren().should.be.deep.equal([ChildContainer]);
   });
@@ -110,5 +110,34 @@ describe('DiodeContainer', () => {
   it('should return empty array if no children defined in spec', () => {
     const Container = create(Component);
     Container.getChildren().should.be.deep.equal([]);
+  });
+
+  it('should merge queries when container is wrapped with another container', () => {
+    const ChildContainer = create(Component, {
+      queries: {
+        child: { type: 'childQuery' },
+      },
+    });
+
+    const InnerContainer = create(Component, {
+      children: [ChildContainer],
+      queries: {
+        inner: { type: 'innerQuery' },
+      },
+    });
+
+    const Container = create(InnerContainer, {
+      queries: {
+        outer: { type: 'outerQuery' },
+      },
+    });
+
+    const expectedQuery = {
+      child: { type: 'childQuery' },
+      inner: { type: 'innerQuery' },
+      outer: { type: 'outerQuery' },
+    };
+
+    Container.query.map.should.be.deep.equal(expectedQuery);
   });
 });


### PR DESCRIPTION
This happens because `hoistStatics` will override the parent's query.