### PR TITLE
Add react-is to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "prettier": "^1.15.3",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
+    "react-is": "^16.8.3",
     "react-testing-library": "^5.3.2"
   },
   "marlint": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {
-    "react": "^16.6.0"
+    "react": "^16.6.0",
+    "react-is": "^16.8.3"
   },
   "optionalDependencies": {
     "isomorphic-fetch": "^2.2.1"
@@ -64,7 +65,6 @@
     "prettier": "^1.15.3",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
-    "react-is": "^16.8.1",
     "react-testing-library": "^5.3.2"
   },
   "marlint": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6759,10 +6759,10 @@ react-dom@^16.6.3:
     prop-types "^15.6.2"
     scheduler "^0.11.2"
 
-react-is@^16.8.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"
-  integrity sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA==
+react-is@^16.8.3:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
 react-testing-library@^5.3.2:
   version "5.3.2"


### PR DESCRIPTION
Add react-is to peer dependencies, because it will cause an error otherwise.