### PR TITLE
[FIX] Append FETCH_ALL_CACHE to Fragment Instead of Inner Fragment

### DIFF
--- a/src/__tests__/DiodePublic.test.js
+++ b/src/__tests__/DiodePublic.test.js
@@ -411,8 +411,6 @@ test("Render error component when cache fails to resolve", async () => {
 });
 
 test("Make sure fetch-all flag doesn't interfere with result", async () => {
-  console.error = jest.fn();
-
   fakeNetworkLayer.sendQueries.mockResolvedValueOnce({
     imageResource: {
       data: {
@@ -461,6 +459,4 @@ test("Make sure fetch-all flag doesn't interfere with result", async () => {
   expect(container.children.length).toBe(2);
   expect(getByText("first-image")).toBeInTheDocument();
   expect(getByText("second-image")).toBeInTheDocument();
-
-  expect(console.error).not.toHaveBeenCalled();
 });

--- a/src/__tests__/fixtures/ImageResourceQuery.js
+++ b/src/__tests__/fixtures/ImageResourceQuery.js
@@ -1,0 +1,30 @@
+import Diode from "react-diode";
+
+export default {
+  type: "imageResource",
+  request(fragment, params, options) {
+    const crNames = Object.keys(fragment);
+
+    const imageResources = crNames.map(name => {
+      const entry = fragment[name];
+      const entryKeys = Object.keys(entry);
+      const entries = entryKeys.map(key => {
+        return {
+          key
+        };
+      });
+
+      return { name, entries };
+    });
+
+    const url = "http://localhost:5000/v2/mobile/imageResource";
+    const method = "post";
+    const payload = { imageResources };
+    return Diode.queryRequest(url, method, payload);
+  },
+  resolve(response, fragment, options) {
+    return {
+      ...response.data.imageResources
+    };
+  }
+};

--- a/src/cache/DiodeCache.js
+++ b/src/cache/DiodeCache.js
@@ -3,7 +3,7 @@ import Store from "../store/DiodeStore";
 
 export const CacheContext = React.createContext(null);
 
-export const FETCH_ALL_CACHE = "__DIODE_FAC__";
+export const FETCH_ALL_CACHE = "__fac__";
 
 export class DiodeCache {
   constructor(cache, options) {

--- a/src/cache/DiodeCache.js
+++ b/src/cache/DiodeCache.js
@@ -37,11 +37,7 @@ export class DiodeCache {
         }
 
         if (innerFragmentKeys.length === 0) {
-          if (
-            cachedFragment &&
-            typeof cachedFragment === "object" &&
-            Array.isArray(cache[FETCH_ALL_CACHE])
-          ) {
+          if (Array.isArray(cache[FETCH_ALL_CACHE])) {
             // might already cache fetch-all
             return !cache[FETCH_ALL_CACHE].includes(fragment);
           }

--- a/src/cache/DiodeCache.js
+++ b/src/cache/DiodeCache.js
@@ -3,7 +3,7 @@ import Store from "../store/DiodeStore";
 
 export const CacheContext = React.createContext(null);
 
-export const FETCH_ALL_CACHE = "__fac__";
+export const FETCH_ALL_CACHE = "__DIODE_FAC__";
 
 export class DiodeCache {
   constructor(cache, options) {
@@ -37,9 +37,13 @@ export class DiodeCache {
         }
 
         if (innerFragmentKeys.length === 0) {
-          if (cachedFragment && typeof cachedFragment === "object") {
+          if (
+            cachedFragment &&
+            typeof cachedFragment === "object" &&
+            Array.isArray(cache[FETCH_ALL_CACHE])
+          ) {
             // might already cache fetch-all
-            return !cachedFragment[FETCH_ALL_CACHE];
+            return !cache[FETCH_ALL_CACHE].includes(fragment);
           }
 
           return cachedFragment === undefined;

--- a/src/store/DiodeStore.js
+++ b/src/store/DiodeStore.js
@@ -25,8 +25,8 @@ import type { DiodeQueryRequest } from "../query/DiodeQueryRequest";
 
 function markFetchAllCache(response, queries) {
   // mark special fetch-all case so our cache is aware
-  try {
-    queries.forEach(query => {
+  queries.forEach(query => {
+    try {
       Object.keys(query.fragment).forEach(fragmentKey => {
         const fragmentResponse = response[query.type][fragmentKey];
         if (
@@ -40,8 +40,8 @@ function markFetchAllCache(response, queries) {
           response[query.type][FETCH_ALL_CACHE].push(fragmentKey);
         }
       });
-    });
-  } catch (err) {}
+    } catch (err) {}
+  });
 
   return response;
 }

--- a/src/store/DiodeStore.js
+++ b/src/store/DiodeStore.js
@@ -23,28 +23,25 @@ import type {
 } from "../tools/DiodeTypes";
 import type { DiodeQueryRequest } from "../query/DiodeQueryRequest";
 
-/*
-  Possible Errors:
-  1. Fragments of the query is not an object.
-*/
-
 function markFetchAllCache(response, queries) {
   // mark special fetch-all case so our cache is aware
-  queries.forEach(query => {
-    try {
+  try {
+    queries.forEach(query => {
       Object.keys(query.fragment).forEach(fragmentKey => {
         const fragmentResponse = response[query.type][fragmentKey];
         if (
           Object.keys(query.fragment[fragmentKey]).length === 0 &&
           fragmentResponse
         ) {
-          fragmentResponse[FETCH_ALL_CACHE] = true;
+          if (Array.isArray(response[query.type][FETCH_ALL_CACHE]) === false) {
+            response[query.type][FETCH_ALL_CACHE] = [];
+          }
+
+          response[query.type][FETCH_ALL_CACHE].push(fragmentKey);
         }
       });
-    } catch (err) {
-      throw new Error("Query fragments must be an Object type");
-    }
-  });
+    });
+  } catch (err) {}
 
   return response;
 }
@@ -125,7 +122,10 @@ class DiodeStore {
         // If fragment is already cached and all data in the fragment is
         // already fetched, remove all fragments. Otherwise, fetch all
         // fragments.
-        if (cachedFragment && cachedFragment[FETCH_ALL_CACHE]) {
+        if (
+          Array.isArray(cache[FETCH_ALL_CACHE]) &&
+          cache[FETCH_ALL_CACHE].includes(fragmentKey)
+        ) {
           return;
         }
 


### PR DESCRIPTION
1. Fix error when fetching all inner fragments and trying to map all the inner fragments because of `__fac__` flag (See `DiodePublic.test.js`). This PR change the current implementation of `__fac__` flag. Instead of adding `__fac__` to inner fragment, it creates a list of fetched-all inner fragments in the fragment level so mapping inner fragments is safer.

**Example of Proposed Solution Result:**
```diff
imageResource: {
  sample: {
    image1: {
      key: 'key-1',
      title: 'title-1'
    },
    image2: {
      key: 'key-2',
      title: 'title-2'
    },
-   __fac__: true
  }
+ __fac__: ['sample']
}
```

2. Remove `throw` from `catch` block in `markFetchAllCache` for Diode containers that have a query with an inner fragment value like `null` or `string` (for backward compatibility, might need to investigate further what those values are used for).