### PR TITLE
Fix fac Cache merging bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "homepage": "https://github.com/traveloka/react-diode#readme",
   "dependencies": {
-    "deep-extend": "^0.6.0",
     "hoist-non-react-statics": "^2.5.0",
     "lodash.find": "^4.3.0",
+    "lodash.mergewith": "^4.6.1",
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {

--- a/src/__tests__/DiodePublic.test.js
+++ b/src/__tests__/DiodePublic.test.js
@@ -152,32 +152,6 @@ test("do not fetch if already in cache", async () => {
   expect(fakeNetworkLayer.sendQueries).toBeCalledTimes(++fetchCount);
   expect(container.firstChild).toHaveTextContent("new world!");
 
-  /*
-    const ContainerA = Diode.createRootContainer(ComponentA, {
-    queries: {
-      imageSlider: Diode.createQuery(ImageSliderQuery, {
-        sample: {}
-      })
-    }
-  });
-
-  const ContainerB = Diode.createRootContainer(ComponentB, {
-    queries: {
-      imageSlider: Diode.createQuery(ImageSliderQuery, {
-        sample: {}
-      })
-    }
-  });
-
-  const ContainerC = Diode.createRootContainer(ComponentC, {
-    queries: {
-      imageSlider: Diode.createQuery(ImageSliderQuery, {
-        test: {}
-      })
-    }
-  });
-  */
-
   // re-render other component with different queries
   rerender(
     <Diode.CacheProvider value={cache}>

--- a/src/__tests__/DiodePublic.test.js
+++ b/src/__tests__/DiodePublic.test.js
@@ -1,5 +1,4 @@
 import React from "react";
-import ReactDOMServer from "react-dom/server";
 import { render, waitForElement } from "react-testing-library";
 import "jest-dom/extend-expect";
 import "react-testing-library/cleanup-after-each";
@@ -24,15 +23,9 @@ test("do not fetch if already in cache", async () => {
   const ComponentX = props => <div>{props.contentResource.hello.world}</div>;
   const ComponentY = props => <div>{props.contentResource.hello.world}</div>;
   const ComponentZ = props => <div>{props.contentResource.new.world}</div>;
-  const ComponentA = props => (
-    <div>{props.imageSlider.sample.map(image => image.title)}</div>
-  );
-  const ComponentB = props => (
-    <div>{props.imageSlider.sample.map(image => image.title)}</div>
-  );
-  const ComponentC = props => (
-    <div>{props.imageSlider.test.map(image => image.title)}</div>
-  );
+  const ComponentA = props => <div>{props.contentResource.sample.title}</div>;
+  const ComponentB = props => <div>{props.contentResource.sample.title}</div>;
+  const ComponentC = props => <div>{props.contentResource.test.title}</div>;
 
   const ContainerX = Diode.createRootContainer(ComponentX, {
     queries: {
@@ -66,7 +59,7 @@ test("do not fetch if already in cache", async () => {
 
   const ContainerA = Diode.createRootContainer(ComponentA, {
     queries: {
-      imageSlider: Diode.createQuery(ImageSliderQuery, {
+      contentResource: Diode.createQuery(ContentResourceQuery, {
         sample: {}
       })
     }
@@ -74,7 +67,7 @@ test("do not fetch if already in cache", async () => {
 
   const ContainerB = Diode.createRootContainer(ComponentB, {
     queries: {
-      imageSlider: Diode.createQuery(ImageSliderQuery, {
+      contentResource: Diode.createQuery(ContentResourceQuery, {
         sample: {}
       })
     }
@@ -82,7 +75,7 @@ test("do not fetch if already in cache", async () => {
 
   const ContainerC = Diode.createRootContainer(ComponentC, {
     queries: {
-      imageSlider: Diode.createQuery(ImageSliderQuery, {
+      contentResource: Diode.createQuery(ContentResourceQuery, {
         test: {}
       })
     }
@@ -112,16 +105,20 @@ test("do not fetch if already in cache", async () => {
       }
     })
     .mockResolvedValueOnce({
-      imageSlider: {
+      contentResource: {
         data: {
-          sample: [{ title: "image1" }]
+          contentResources: {
+            sample: { title: "text1" }
+          }
         }
       }
     })
     .mockResolvedValueOnce({
-      imageSlider: {
+      contentResource: {
         data: {
-          test: [{ title: "image2" }]
+          contentResources: {
+            test: { title: "text2" }
+          }
         }
       }
     });
@@ -155,6 +152,32 @@ test("do not fetch if already in cache", async () => {
   expect(fakeNetworkLayer.sendQueries).toBeCalledTimes(++fetchCount);
   expect(container.firstChild).toHaveTextContent("new world!");
 
+  /*
+    const ContainerA = Diode.createRootContainer(ComponentA, {
+    queries: {
+      imageSlider: Diode.createQuery(ImageSliderQuery, {
+        sample: {}
+      })
+    }
+  });
+
+  const ContainerB = Diode.createRootContainer(ComponentB, {
+    queries: {
+      imageSlider: Diode.createQuery(ImageSliderQuery, {
+        sample: {}
+      })
+    }
+  });
+
+  const ContainerC = Diode.createRootContainer(ComponentC, {
+    queries: {
+      imageSlider: Diode.createQuery(ImageSliderQuery, {
+        test: {}
+      })
+    }
+  });
+  */
+
   // re-render other component with different queries
   rerender(
     <Diode.CacheProvider value={cache}>
@@ -165,19 +188,7 @@ test("do not fetch if already in cache", async () => {
   // different key, fetch again
   await waitForElement(() => container.firstChild);
   expect(fakeNetworkLayer.sendQueries).toBeCalledTimes(++fetchCount);
-  expect(container.firstChild).toHaveTextContent("image1");
-
-  // re-render other component with same queries
-  rerender(
-    <Diode.CacheProvider value={cache}>
-      <ContainerB />
-    </Diode.CacheProvider>
-  );
-
-  // already in cache, no additional fetch
-  await waitForElement(() => container.firstChild);
-  expect(fakeNetworkLayer.sendQueries).toBeCalledTimes(fetchCount);
-  expect(container.firstChild).toHaveTextContent("image1");
+  expect(container.firstChild).toHaveTextContent("text1");
 
   // re-render other component with different queries
   rerender(
@@ -186,10 +197,22 @@ test("do not fetch if already in cache", async () => {
     </Diode.CacheProvider>
   );
 
-  // different key, fetch again
+  // already in cache, no additional fetch
   await waitForElement(() => container.firstChild);
   expect(fakeNetworkLayer.sendQueries).toBeCalledTimes(++fetchCount);
-  expect(container.firstChild).toHaveTextContent("image2");
+  expect(container.firstChild).toHaveTextContent("text2");
+
+  // re-render other component with same queries
+  rerender(
+    <Diode.CacheProvider value={cache}>
+      <ContainerB />
+    </Diode.CacheProvider>
+  );
+
+  // different key, fetch again
+  await waitForElement(() => container.firstChild);
+  expect(fakeNetworkLayer.sendQueries).toBeCalledTimes(fetchCount);
+  expect(container.firstChild).toHaveTextContent("text1");
 });
 
 test("able to understand fetch-all pattern", async () => {

--- a/src/__tests__/DiodePublic.test.js
+++ b/src/__tests__/DiodePublic.test.js
@@ -24,8 +24,8 @@ test("do not fetch if already in cache", async () => {
   const ComponentY = props => <div>{props.contentResource.hello.world}</div>;
   const ComponentZ = props => <div>{props.contentResource.new.world}</div>;
   const ComponentA = props => <div>{props.contentResource.sample.title}</div>;
-  const ComponentB = props => <div>{props.contentResource.sample.title}</div>;
-  const ComponentC = props => <div>{props.contentResource.test.title}</div>;
+  const ComponentB = props => <div>{props.contentResource.test.title}</div>;
+  const ComponentC = props => <div>{props.contentResource.sample.title}</div>;
 
   const ContainerX = Diode.createRootContainer(ComponentX, {
     queries: {
@@ -68,7 +68,7 @@ test("do not fetch if already in cache", async () => {
   const ContainerB = Diode.createRootContainer(ComponentB, {
     queries: {
       contentResource: Diode.createQuery(ContentResourceQuery, {
-        sample: {}
+        test: {}
       })
     }
   });
@@ -76,7 +76,7 @@ test("do not fetch if already in cache", async () => {
   const ContainerC = Diode.createRootContainer(ComponentC, {
     queries: {
       contentResource: Diode.createQuery(ContentResourceQuery, {
-        test: {}
+        sample: {}
       })
     }
   });
@@ -167,7 +167,7 @@ test("do not fetch if already in cache", async () => {
   // re-render other component with different queries
   rerender(
     <Diode.CacheProvider value={cache}>
-      <ContainerC />
+      <ContainerB />
     </Diode.CacheProvider>
   );
 
@@ -179,7 +179,7 @@ test("do not fetch if already in cache", async () => {
   // re-render other component with same queries
   rerender(
     <Diode.CacheProvider value={cache}>
-      <ContainerB />
+      <ContainerC />
     </Diode.CacheProvider>
   );
 

--- a/src/cache/DiodeCache.js
+++ b/src/cache/DiodeCache.js
@@ -1,9 +1,8 @@
 import React from "react";
 import Store from "../store/DiodeStore";
+import { FETCH_ALL_CACHE } from "./DiodeCacheConstant";
 
 export const CacheContext = React.createContext(null);
-
-export const FETCH_ALL_CACHE = "__fac__";
 
 export class DiodeCache {
   constructor(cache, options) {

--- a/src/cache/DiodeCacheConstant.js
+++ b/src/cache/DiodeCacheConstant.js
@@ -1,0 +1,1 @@
+export const FETCH_ALL_CACHE = "__fac__";

--- a/src/container/DiodeContainer.js
+++ b/src/container/DiodeContainer.js
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import * as reactIs from "react-is";
-import deepExtend from "deep-extend";
+import mergeWith from "lodash.mergewith";
 import objectAssign from "object-assign";
 import hoistStatics from "hoist-non-react-statics";
 import DiodeContainerQuery from "../query/DiodeContainerQuery";
@@ -182,7 +182,7 @@ export function createContainer(
     }
   };
 
-  ContainerConstructor.query = deepExtend(query, Component.query);
+  ContainerConstructor.query = mergeWith(query, Component.query);
   ContainerConstructor.displayName = containerName;
   ContainerConstructor.componentName = componentName;
 

--- a/src/query/DiodeContainerQuery.js
+++ b/src/query/DiodeContainerQuery.js
@@ -1,7 +1,7 @@
 /**
  * @flow
  */
-import deepExtend from "deep-extend";
+import mergeWith from "lodash.mergewith";
 import type { DiodeQueryMap } from "../tools/DiodeTypes";
 import type { DiodeContainer } from "../container/DiodeContainer";
 
@@ -66,8 +66,8 @@ class DiodeContainerQuery {
       if (existingQueryType) {
         const { fragmentStructure: existingFragment } = existingQueryType;
         const { fragmentStructure: newFragment } = query;
-        deepExtend(existingFragment, newFragment);
-        deepExtend(existingQueryType.params, query.params);
+        mergeWith(existingFragment, newFragment);
+        mergeWith(existingQueryType.params, query.params);
       } else if (query.type) {
         this._queryTypeMap[query.type] = query;
       } else {
@@ -105,7 +105,7 @@ class DiodeContainerQuery {
         if (existingQueryType) {
           const { fragmentStructure: existingFragment } = existingQueryType;
           const { fragmentStructure: newFragment } = childQuery;
-          deepExtend(existingFragment, newFragment);
+          mergeWith(existingFragment, newFragment);
         } else {
           this._queryTypeMap[childQuery.type] = childQuery;
         }

--- a/src/query/DiodeRootQuery.js
+++ b/src/query/DiodeRootQuery.js
@@ -1,7 +1,7 @@
 /**
  * @flow
  */
-import deepExtend from "deep-extend";
+import mergeWith from "lodash.mergewith";
 import type DiodeContainerQuery from "./DiodeContainerQuery";
 import type { DiodeQuery, Variables } from "../tools/DiodeTypes";
 
@@ -30,7 +30,7 @@ class DiodeRootQuery {
    *
    */
   setVariables(variables: Variables): void {
-    deepExtend(this._variables, variables);
+    mergeWith(this._variables, variables);
   }
 
   /**

--- a/src/store/DiodeStore.js
+++ b/src/store/DiodeStore.js
@@ -172,6 +172,8 @@ class DiodeStore {
       .filter(Boolean);
 
     const response = await this._fetchQueries(queries, options);
+    // customizer function is required. Otherwise, __fac__ array in cache will be
+    // replaced, not concat when updating cache
     mergeWith(
       this.cache,
       markFetchAllCache(response, queries),

--- a/src/store/DiodeStore.js
+++ b/src/store/DiodeStore.js
@@ -1,7 +1,7 @@
 /**
  * @flow
  */
-import deepExtend from "deep-extend";
+import mergeWith from "lodash.mergewith";
 import resolveContainerProps from "../container/resolveContainerProps";
 import DiodeNetworkLayer from "../network/DiodeNetworkLayer";
 import DiodeRootQuery from "../query/DiodeRootQuery";
@@ -12,7 +12,7 @@ import {
   getQueryRequests,
   generateQueryRequest
 } from "../query/DiodeQueryRequest";
-import { FETCH_ALL_CACHE } from "../cache/DiodeCache";
+import { FETCH_ALL_CACHE } from "../cache/DiodeCacheConstant";
 
 import type { DiodeRootContainer } from "../container/DiodeRootContainer";
 import type {
@@ -172,7 +172,15 @@ class DiodeStore {
       .filter(Boolean);
 
     const response = await this._fetchQueries(queries, options);
-    deepExtend(this.cache, markFetchAllCache(response, queries));
+    mergeWith(
+      this.cache,
+      markFetchAllCache(response, queries),
+      function customizer(objValue, srcValue) {
+        if (Array.isArray(objValue)) {
+          return objValue.concat(srcValue);
+        }
+      }
+    );
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5270,6 +5270,11 @@ lodash.merge@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
   integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
+lodash.mergewith@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+  integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"


### PR DESCRIPTION
**Changelog**
1. Replace `deep-extend` to `mergeWith`
2. Fix test because it did not catch some bugs before

**Bug Explanation**
Previously, if any fragment of `contentResource` fetches using `fac` pattern, it will not register that the fragment is fetched all properly. As a result, client-side redirection will always call `batchApiData`.

Why is that? After react-diode fetches resource from API, it will update the cache using `deep-extend` with the response. Since react-diode keeps track of `fac` in array format, `deep-extend` will replace the `fac` array with a new one, because `deep-extend` use something similar to `Object.assign` 😢 . 

Meanwhile, `lodash.mergeWith` has an extra `customizer` prop, where we can customize our merging behavior. Without the `customizer` prop, it will behave exactly the same as `deep-extend` 👍 
