### PR TITLE
[FIX] Replace mergeWith with deepExtend

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/traveloka/react-diode#readme",
   "dependencies": {
+    "deep-extend": "^0.6.0",
     "hoist-non-react-statics": "^2.5.0",
     "lodash.find": "^4.3.0",
     "lodash.mergewith": "^4.6.1",

--- a/src/__tests__/DiodeQuery.test.js
+++ b/src/__tests__/DiodeQuery.test.js
@@ -1,0 +1,45 @@
+import Diode from "../DiodePublic";
+
+import contentResourceQuery from "./fixtures/ContentResourceQuery";
+
+describe("Query merging", () => {
+  test("Merge container query with wrapped component query", () => {
+    function Foo() {
+      return <div />;
+    }
+
+    const FooContainer = Diode.createContainer(Foo, {
+      queries: {
+        contentResource: Diode.createQuery(contentResourceQuery, {
+          hello: {
+            world: null
+          }
+        })
+      }
+    });
+
+    const AppContainer = Diode.createRootContainer(FooContainer, {
+      queries: {
+        contentResource: Diode.createQuery(contentResourceQuery, {
+          hello: {
+            tvlk: null
+          }
+        })
+      }
+    });
+
+    const queryMap = AppContainer.query._containerQuery.map;
+
+    expect(queryMap).toEqual({
+      contentResource: {
+        fragmentStructure: {
+          hello: {
+            tvlk: null,
+            world: null
+          }
+        },
+        paramsStructure: {}
+      }
+    });
+  });
+});

--- a/src/container/DiodeContainer.js
+++ b/src/container/DiodeContainer.js
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import * as reactIs from "react-is";
-import mergeWith from "lodash.mergewith";
+import deepExtend from "deep-extend";
 import objectAssign from "object-assign";
 import hoistStatics from "hoist-non-react-statics";
 import DiodeContainerQuery from "../query/DiodeContainerQuery";
@@ -182,7 +182,7 @@ export function createContainer(
     }
   };
 
-  ContainerConstructor.query = mergeWith(query, Component.query);
+  ContainerConstructor.query = deepExtend(query, Component.query);
   ContainerConstructor.displayName = containerName;
   ContainerConstructor.componentName = componentName;
 


### PR DESCRIPTION
`mergeWith` doesn't merge the container and wrapped component query. Instead, it replaces the container query with the wrapped component query which causes missing container query fragments. Reverting to `deepExtend` for now. I also add a test to prevent this issue from happening again. 🙇 