### PR TITLE
[FIX] Only fetch non-cached resources in client

### DIFF
--- a/src/__tests__/DiodePublic.test.js
+++ b/src/__tests__/DiodePublic.test.js
@@ -6,7 +6,6 @@ import "react-testing-library/cleanup-after-each";
 import Diode from "../DiodePublic";
 import ContentResourceQuery from "./fixtures/ContentResourceQuery";
 import ImageResourceQuery from "./fixtures/ImageResourceQuery";
-import ImageSliderQuery from "./fixtures/ImageSliderQuery";
 
 const fakeNetworkLayer = {
   sendQueries: jest.fn()

--- a/src/__tests__/DiodeQuery.test.js
+++ b/src/__tests__/DiodeQuery.test.js
@@ -1,6 +1,21 @@
-import Diode from "../DiodePublic";
+import React from "react";
+import { render, waitForElement } from "react-testing-library";
+import "jest-dom/extend-expect";
+import "react-testing-library/cleanup-after-each";
 
-import contentResourceQuery from "./fixtures/ContentResourceQuery";
+import Diode from "../DiodePublic";
+import ContentResourceQuery from "./fixtures/ContentResourceQuery";
+
+const fakeNetworkLayer = {
+  sendQueries: jest.fn()
+};
+
+Diode.injectNetworkLayer(fakeNetworkLayer);
+
+afterEach(() => {
+  fakeNetworkLayer.sendQueries.mockClear();
+  fakeNetworkLayer.sendQueries.mockReset();
+});
 
 describe("Query merging", () => {
   test("Merge container query with wrapped component query", () => {
@@ -10,7 +25,7 @@ describe("Query merging", () => {
 
     const FooContainer = Diode.createContainer(Foo, {
       queries: {
-        contentResource: Diode.createQuery(contentResourceQuery, {
+        contentResource: Diode.createQuery(ContentResourceQuery, {
           hello: {
             world: null
           }
@@ -20,7 +35,7 @@ describe("Query merging", () => {
 
     const AppContainer = Diode.createRootContainer(FooContainer, {
       queries: {
-        contentResource: Diode.createQuery(contentResourceQuery, {
+        contentResource: Diode.createQuery(ContentResourceQuery, {
           hello: {
             tvlk: null
           }
@@ -41,5 +56,83 @@ describe("Query merging", () => {
         paramsStructure: {}
       }
     });
+  });
+});
+
+test("Cached fragments should not be sent as payload", async () => {
+  const ComponentX = props => <div>{props.contentResource.hello.world}</div>;
+  const ComponentY = props => <div>{props.contentResource.hello.world}</div>;
+
+  const ContainerX = Diode.createRootContainer(ComponentX, {
+    queries: {
+      contentResource: Diode.createQuery(ContentResourceQuery, {
+        hello: {
+          world: null
+        }
+      })
+    }
+  });
+  const ContainerY = Diode.createRootContainer(ComponentY, {
+    queries: {
+      contentResource: Diode.createQuery(ContentResourceQuery, {
+        hello: {
+          world: null
+        },
+        fetchAll: {}
+      })
+    }
+  });
+
+  // Fake Network Layer
+  fakeNetworkLayer.sendQueries
+    .mockResolvedValueOnce({
+      contentResource: {
+        data: {
+          contentResources: {
+            hello: {
+              world: "Hello, World!"
+            }
+          }
+        }
+      }
+    })
+    .mockResolvedValueOnce({
+      contentResource: {
+        data: {
+          contentResources: {
+            fetchAll: {
+              buggy: "bug"
+            }
+          }
+        }
+      }
+    });
+
+  // render other component with same queries
+  const cache = Diode.createCache({});
+  const { container, rerender } = render(
+    <Diode.CacheProvider value={cache}>
+      <ContainerX />
+    </Diode.CacheProvider>
+  );
+
+  await waitForElement(() => container.firstChild);
+
+  rerender(
+    <Diode.CacheProvider value={cache}>
+      <ContainerY />
+    </Diode.CacheProvider>
+  );
+
+  await waitForElement(() => container.firstChild);
+
+  // Checking the params sent to sendQueries when it is called
+  /*
+    First array: calls
+    Second array: params
+    Third array: query
+  */
+  expect(fakeNetworkLayer.sendQueries.mock.calls[1][0][0].payload).toEqual({
+    contentResources: [{ name: "fetchAll", entries: [] }]
   });
 });

--- a/src/store/DiodeStore.js
+++ b/src/store/DiodeStore.js
@@ -140,10 +140,13 @@ class DiodeStore {
 
       // this query type might be partially cached
       // check specific fragment
-      filteredFragments[fragmentKey] = {};
       innerFragmentKeys.forEach(innerKey => {
         if (cachedFragment && cachedFragment[innerKey]) {
           return;
+        }
+
+        if (!filteredFragments[fragmentKey]) {
+          filteredFragments[fragmentKey] = {};
         }
 
         filteredFragments[fragmentKey][innerKey] = innerFragment[innerKey];


### PR DESCRIPTION
### Summary
Fix cases where all resources are fetched using `fetch-all` pattern in client. I will detail below the case where this happens.

Case:
Component A fetches `contentResource` with fragment:
```
{
    hello: {
        world: null
    }
}
```
Then, Component B fetches `contentResource` with fragment:
```
{
    hello: {
        world: null
    },
    fetchAll: {},
}
```

If Component B has a key that has not been fetched in client yet, diode currently also fetches `hello` fragment using `fetch-all` pattern because of this bug.

### Why?
Before this fix, `filteredFragments[fragmentKey] = {}` is always returned even though the fragment is already cached. `fetch-all` pattern has the same fragment as `filteredFragments[fragmentKey] = {}`.