### PR TITLE
Fix missing resource query when calling batchapidata API

### DIFF
--- a/src/store/DiodeStore.js
+++ b/src/store/DiodeStore.js
@@ -165,9 +165,6 @@ class DiodeStore {
       .compile()
       .map(query => {
         const { fragment, params } = this.filterCachedFragments(query);
-        if (Object.keys(fragment).length === 0) {
-          return null;
-        }
 
         const queryRequestInfo = query.request(fragment, params, options);
         return generateQueryRequest(query, queryRequestInfo);


### PR DESCRIPTION
Currently, we are batching CR and IR requests using `BatchQuery` to `/v2/mobile/batchapidata`. 

It seems that the API does not take `null` or `undefined` `contentResource` as payload parameter. 

Ever since we implemented caching, resource fragments that are already cached is filtered and not fetched anymore. As a result, if all fragments of that query are already cached, the query will be filtered without a trace. I am removing this code to ensure that `contentResource` query will still be sent to `batchapidata` API as an empty array.