### PR TITLE
Fix afterFetchCallback Promise Condition

### DIFF
--- a/src/container/DiodeContainer.js
+++ b/src/container/DiodeContainer.js
@@ -47,8 +47,9 @@ class DiodeQueryFetcher extends React.Component {
       await new Promise(resolve => {
         if (typeof this.props.afterFetchCallback === "function") {
           this.props.afterFetchCallback(resolve, cache.getContents());
+        } else {
+          resolve();
         }
-        resolve();
       });
 
       this.setState({ isLoading: false });

--- a/src/container/DiodeContainer.js
+++ b/src/container/DiodeContainer.js
@@ -44,11 +44,12 @@ class DiodeQueryFetcher extends React.Component {
     try {
       await cache.resolve(query);
 
-      if (typeof this.props.afterFetchCallback === "function") {
-        await new Promise(resolve =>
-          this.props.afterFetchCallback(resolve, cache.getContents())
-        );
-      }
+      await new Promise(resolve => {
+        if (typeof this.props.afterFetchCallback === "function") {
+          this.props.afterFetchCallback(resolve, cache.getContents());
+        }
+        resolve();
+      });
 
       this.setState({ isLoading: false });
     } catch (error) {


### PR DESCRIPTION
Somehow, `async-await-to-promises` mangled the previous condition to the one below, which is completely wrong.
```
if (!(_this5.state.isLoading === false)) {
          return Promise.resolve().then(function () {
            return cache.resolve(query);
          }).then(function () {
            return new Promise(function (resolve) {
              return _this2.props.afterFetchCallback(resolve, cache.getContents());
            });
          }).then(function () {
            if (typeof _this5.props.afterFetchCallback === "function") ;

            _this5.setState({
              isLoading: false
            });
          })
}
```

Instead, had to move the `afterFetchCallback` checking into the Promise.