### PR TITLE
fix react warning regarding function factory

### DIFF
--- a/src/container/DiodeContainer.js
+++ b/src/container/DiodeContainer.js
@@ -148,21 +148,13 @@ export function createContainer(
 ): DiodeContainer {
   /* istanbul ignore next */
   const componentName = Component.displayName || Component.name;
-  const containerName = `Diode(${componentName})`;
   const query = new DiodeContainerQuery(
     componentName,
     spec.queries,
     spec.children
   );
 
-  let Container;
-  function ContainerConstructor(props) {
-    /* istanbul ignore else */
-    if (!Container) {
-      Container = createContainerComponent(Component, spec, query);
-    }
-    return new Container(props);
-  }
+  const ContainerConstructor = createContainerComponent(Component, spec, query);
 
   ContainerConstructor.setWrapperInfo = function setWrapperInfo(wrapperInfo) {
     objectAssign(spec.wrapperInfo, wrapperInfo);
@@ -185,7 +177,6 @@ export function createContainer(
   };
 
   ContainerConstructor.query = deepExtend(query, Component.query);
-  ContainerConstructor.displayName = containerName;
   ContainerConstructor.componentName = componentName;
 
   return hoistStatics(ContainerConstructor, Component, { query: true });


### PR DESCRIPTION
```
Warning: The <Diode(ComponentName) /> component appears to be a function component that returns a class instance. Change Diode(ComponentName) to a class that extends React.Component instead. If you can't use a class try ass
igning the prototype on the function as a workaround. `Diode(ComponentName).prototype = React.Component.prototype`. Don't use an arrow function since it cannot be called with `new` by React.
```